### PR TITLE
Force resolve patched `lodash` version that is not vulnerable

### DIFF
--- a/app-embed-example/package.json
+++ b/app-embed-example/package.json
@@ -34,5 +34,8 @@
     "http-proxy-middleware": "^0.19.0",
     "nodemon": "^1.18.9",
     "prettier": "^1.15.2"
+  },
+  "resolutions": {
+    "lodash": "^4.17.21"
   }
 }

--- a/app-embed-example/yarn.lock
+++ b/app-embed-example/yarn.lock
@@ -6149,10 +6149,10 @@ lodash.uniq@^4.5.0:
   resolved "https://registry.yarnpkg.com/lodash.uniq/-/lodash.uniq-4.5.0.tgz#d0225373aeb652adc1bc82e4945339a842754773"
   integrity sha1-0CJTc662Uq3BvILklFM5qEJ1R3M=
 
-"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.4, lodash@^4.17.5:
-  version "4.17.11"
-  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.11.tgz#b39ea6229ef607ecd89e2c8df12536891cac9b8d"
-  integrity sha512-cQKh8igo5QUhZ7lg38DYWAxMvjSAKG0A8wGSVimP07SIUEK2UO+arSRKbRZWtelMtN5V0Hkwh5ryOto/SshYIg==
+"lodash@>=3.5 <5", lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5:
+  version "4.17.21"
+  resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
+  integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
 loglevel@^1.4.1:
   version "1.6.1"


### PR DESCRIPTION
### Status
PENDING REVIEW

### What does this PR accomplish?
- Force resolves `lodash` to the first non-vulnerable version
- Fixes CVE-2021-23337 security issue