### PR TITLE
fix app-embed-example

### DIFF
--- a/app-embed-example/src/setupProxy.js
+++ b/app-embed-example/src/setupProxy.js
@@ -1,5 +1,5 @@
-const proxy = require("http-proxy-middleware");
+const { createProxyMiddleware } = require("http-proxy-middleware");
 
-module.exports = app => {
-  app.use(proxy("/api", { target: "http://localhost:3002/" }));
+module.exports = (app) => {
+  app.use(createProxyMiddleware("/api", { target: "http://localhost:3002/" }));
 };


### PR DESCRIPTION
Fixes `app-embed-example/src/setupProxy.js` throws `proxy is not a function` error by using `createProxyMiddleware` function 
