### PR TITLE
*_JWT_SHARED_SECRET env var naming

### DIFF
--- a/app-embed-example/server.js
+++ b/app-embed-example/server.js
@@ -6,7 +6,7 @@ const PORT = process.env.PORT || 8080;
 
 const METABASE_URL = process.env.METABASE_URL || "http://localhost:3000";
 const METABASE_JWT_SHARED_SECRET =
-  process.env.METABASE_JWT_SHARED_SECRET ||
+  process.env.MB_JWT_SHARED_SECRET ||
   "ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff";
 
 // This matches a user in the Sample Dataset


### PR DESCRIPTION
Shouldn't the server.js file use the `MB_` env var name set in the docker compose file? (also referenced in the readme as MB_)